### PR TITLE
Reducing number of consumers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,7 +44,7 @@ declare module '@dojot/dojot-module' {
         connect(): void;
         subscribe(topic: string): void;
         consume(maxMessages?: number): Promise<any>;
-        onMessageListener(callback: (data: any) => void): void;
+        // onMessageListener(callback: (data: any) => void): void;
         commit(): void;
         disconnect(): Promise<any>;
     }

--- a/lib/kafka/Consumer.js
+++ b/lib/kafka/Consumer.js
@@ -6,6 +6,10 @@ class Consumer {
   constructor(consumerConfig) {
     console.log('Creating a new Kafka consumer...');
     this.consumer = new Kafka.KafkaConsumer(consumerConfig);
+    this.isReady = false;
+
+    this.messageCallbacks = [];
+    this.subscriptions = [];
   }
 
   connect() {
@@ -20,17 +24,39 @@ class Consumer {
       this.consumer.on("ready", () => {
         logger.info("Consumer is connected");
         clearTimeout(timeoutTrigger);
+        this.isReady = true;
+        if (this.subscriptions.length != 0) {
+          this.consumer.subscribe(this.subscriptions);
+        }
+        // setInterval(() => {
+        this.consumer.consume();
+        //   logger.info("Consumed 1 message.");
+        // }, 1000);
+        for (let callback of this.messageCallbacks) {
+          logger.info("Executing previously scheduled callbacks");
+          callback();
+        }
+        this.messageCallbacks = [];
         resolve();
       });
     });
 
-    this.consumer.connect(null);
+    this.consumer.connect();
     return readyPromise;
   }
 
   subscribe(topic) {
-    this.consumer.subscribe([topic]);
-    console.log(`Subscribed to topic ${topic}`);
+    if (this.isReady == false) {
+      this.subscriptions.push(topic);  
+    } else {
+      logger.debug(`Unsubscribing from topics ${this.subscriptions}`);
+      this.consumer.unsubscribe();
+      logger.debug(`Adding new topic ${topic}`);
+      this.subscriptions.push(topic);
+      logger.debug(`Subscribing to topics ${this.subscriptions}`);
+      this.consumer.subscribe(this.subscriptions);
+      console.log(`Subscribed to topic ${topic}`);
+    }
   }
 
   consume(maxMessages = 1) {
@@ -47,10 +73,17 @@ class Consumer {
   }
 
   onMessageListener(callback) {
-        this.consumer.consume();
-        this.consumer.on('data', (messages) => {
-          callback(messages);
-        });
+    let consumeCallback = () => {
+      this.consumer.on('data', (messages) => {
+        callback(messages);
+      });
+    };
+    if (this.isReady == false) {
+      this.messageCallbacks.push(consumeCallback);
+    } else {
+      consumeCallback();
+    }
+      
   }
 
   commit() {

--- a/lib/kafka/Consumer.js
+++ b/lib/kafka/Consumer.js
@@ -8,7 +8,7 @@ class Consumer {
     this.consumer = new Kafka.KafkaConsumer(consumerConfig);
     this.isReady = false;
 
-    this.messageCallbacks = [];
+    this.messageCallbacks = {};
     this.subscriptions = [];
   }
 
@@ -28,15 +28,7 @@ class Consumer {
         if (this.subscriptions.length != 0) {
           this.consumer.subscribe(this.subscriptions);
         }
-        // setInterval(() => {
         this.consumer.consume();
-        //   logger.info("Consumed 1 message.");
-        // }, 1000);
-        for (let callback of this.messageCallbacks) {
-          logger.info("Executing previously scheduled callbacks");
-          callback();
-        }
-        this.messageCallbacks = [];
         resolve();
       });
     });
@@ -45,7 +37,13 @@ class Consumer {
     return readyPromise;
   }
 
-  subscribe(topic) {
+  subscribe(topic, callback) {
+    if (!(topic in this.messageCallbacks)) {
+      this.messageCallbacks[topic] = []
+    }
+
+    this.messageCallbacks[topic].push(callback);
+
     if (this.isReady == false) {
       this.subscriptions.push(topic);  
     } else {
@@ -55,6 +53,13 @@ class Consumer {
       this.subscriptions.push(topic);
       logger.debug(`Subscribing to topics ${this.subscriptions}`);
       this.consumer.subscribe(this.subscriptions);
+      this.consumer.on('data', (kafkaMessage) => {
+        if (kafkaMessage.topic == topic) {
+          for (let callback of this.messageCallbacks[topic]) {
+            callback(kafkaMessage);
+          }
+        }
+      });
       console.log(`Subscribed to topic ${topic}`);
     }
   }
@@ -71,21 +76,6 @@ class Consumer {
       });
     });
   }
-
-  onMessageListener(callback) {
-    let consumeCallback = () => {
-      this.consumer.on('data', (messages) => {
-        callback(messages);
-      });
-    };
-    if (this.isReady == false) {
-      this.messageCallbacks.push(consumeCallback);
-    } else {
-      consumeCallback();
-    }
-      
-  }
-
   commit() {
     this.consumer.commit(null);
   }

--- a/lib/kafka/Consumer.js
+++ b/lib/kafka/Consumer.js
@@ -39,7 +39,7 @@ class Consumer {
 
   subscribe(topic, callback) {
     if (!(topic in this.messageCallbacks)) {
-      this.messageCallbacks[topic] = []
+      this.messageCallbacks[topic] = [];
     }
 
     this.messageCallbacks[topic].push(callback);

--- a/lib/messenger.js
+++ b/lib/messenger.js
@@ -14,10 +14,10 @@ class Messenger {
     this.topicManager = new TopicManager();
     this.eventCallbacks = {};
     this.tenants = [];
-    this.subjects = [];
+    this.subjects = {};
     this.topics = [];
     this.producerTopics = {};
-    this.globalSubjects = [];
+    this.globalSubjects = {};
     this.queuedMessages = [];
     this.instanceId = name + uuid.v4();
     
@@ -55,7 +55,7 @@ class Messenger {
           connectConsumberFn();
         }, 5000);
       });
-    }
+    };
     connectConsumberFn();
 
     let processNewTenantCbk = this._processNewTenant.bind(this);
@@ -109,8 +109,8 @@ class Messenger {
     }
 
     this.tenants.push(data.tenant);
-    for (let subject of this.subjects) {
-      this._bootstrapTenant(subject.subject, data.tenant, subject.mode);
+    for (let subject in this.subjects) {
+      this._bootstrapTenant(subject, data.tenant, this.subjects[subject].mode);
     }
     this.emit(this.config.dojot.subjects.tenancy, this.config.dojot.managementService, "new-tenant", data.tenant);
   }
@@ -160,16 +160,16 @@ class Messenger {
   }
 
   _bootstrapTenant(subject, tenant, mode, isGlobal = false, config = this.config.kafka) {
-    logger.info(`Bootstraping tenant ${tenant} for subject ${subject}.`);
-    logger.info(`Global: ${isGlobal}, mode ${mode}`);
-    let processKafkaMessagesCbk = (messages) => {
+    console.log(`Bootstraping tenant ${tenant} for subject ${subject}.`);
+    console.log(`Global: ${isGlobal}, mode ${mode}`);
+    let processKafkaMessagesFn = (messages) => {
       this._processKafkaMessages(subject, tenant, messages);
     };
+    let processKafkaMessagesCbk = processKafkaMessagesFn.bind(this);
 
     let connectConsumer = (consumer, topic, subject, tenant) => {
       consumer.connect().then(() => {
-        consumer.subscribe(topic);
-        consumer.onMessageListener(processKafkaMessagesCbk);
+        consumer.subscribe(topic, processKafkaMessagesCbk);
       }).catch((error) => {
         logger.warn(`Could not connect consumer: ${error}`);
         logger.warn(`Related info is: ${subject}:${tenant}`);
@@ -191,10 +191,7 @@ class Messenger {
       this.topics.push(topic);
       logger.debug(`config is: ${util.inspect(config, {depth: null})}`);
       if (mode.indexOf('r') != -1) {
-        // let consumer = new Consumer(config.consumer);
-        // connectConsumer(consumer, topic, subject, tenant);
-        this.consumer.subscribe(topic);
-        this.consumer.onMessageListener(processKafkaMessagesCbk);
+        this.consumer.subscribe(topic, processKafkaMessagesCbk);
       }
 
       if (mode.indexOf('w') != -1) {
@@ -224,10 +221,10 @@ class Messenger {
     let associatedTenants = [];
     if (isGlobal === true) {
       associatedTenants = [this.config.dojot.managementService];
-      this.globalSubjects.push({subject, mode});
+      this.globalSubjects[subject] = { mode };
     } else {
       associatedTenants = this.tenants;
-      this.subjects.push({subject, mode});
+      this.subjects[subject] = { mode };
     }
 
     for (let tenant of associatedTenants) {
@@ -236,10 +233,8 @@ class Messenger {
   }
 
   _processKafkaMessages(subject, tenant, messages) {
-    // for (const message of messages) {
       logger.debug(`Received message: ${util.inspect(messages, {depth: null})} `);
       this.emit(subject, tenant, "message", messages.value.toString("utf-8"));
-    // }
   }
 
   publish(subject, tenant, message) {

--- a/lib/messenger.js
+++ b/lib/messenger.js
@@ -162,10 +162,9 @@ class Messenger {
   _bootstrapTenant(subject, tenant, mode, isGlobal = false, config = this.config.kafka) {
     console.log(`Bootstraping tenant ${tenant} for subject ${subject}.`);
     console.log(`Global: ${isGlobal}, mode ${mode}`);
-    let processKafkaMessagesFn = (messages) => {
+    let processKafkaMessagesCbk = (messages) => {
       this._processKafkaMessages(subject, tenant, messages);
     };
-    let processKafkaMessagesCbk = processKafkaMessagesFn.bind(this);
 
     let connectConsumer = (consumer, topic, subject, tenant) => {
       consumer.connect().then(() => {

--- a/lib/messenger.js
+++ b/lib/messenger.js
@@ -43,15 +43,34 @@ class Messenger {
     consumer["group.id"] = this.instanceId;
     this.createChannel(this.config.dojot.subjects.tenancy, "r", true, {consumer});
 
+
+    this.consumer = new Consumer(this.config.kafka.consumer);
+    let connectConsumberFn = () => {
+      this.consumer.connect().then(() => {
+        logger.warn(`Global consumer connected`);
+      }).catch((error) => {
+        logger.warn(`Could not connect consumer: ${error}`);
+        logger.warn("Trying it again in a few seconds.");
+        setTimeout(() => {
+          connectConsumberFn();
+        }, 5000);
+      });
+    }
+    connectConsumberFn();
+
     let processNewTenantCbk = this._processNewTenant.bind(this);
     this.on(this.config.dojot.subjects.tenancy, "message", processNewTenantCbk);
 
     // There should be a auth call here, to get all previous configured
     // tenants.
     auth.getTenants(this.config.auth.host).then((tenants) => {
+      logger.info(`Retrieved list of tenants: ${tenants}.`);
       for (const tenant of tenants){ 
+        logger.info(`Bootstrapping tenant ${tenant}...`);
         this._processNewTenant(this.config.dojot.managementService, JSON.stringify({tenant}));
+        logger.info(`... ${tenant} bootstrapped.`);
       }
+      logger.info(`Finished tenant bootstrapping.`);
     }).catch((error) => {
       logger.error("Could not get list of current tenants.");
       logger.error(`Error is: ${error}`);
@@ -161,6 +180,8 @@ class Messenger {
       });
     };
 
+
+    logger.debug(`Requesting topic for ${subject}@${tenant}...`);
     this.topicManager.getTopic(subject, tenant, this.config.databroker.host, isGlobal).then((topic) => {
       if (this.topics.indexOf(topic) != -1) {
         logger.info(`already have a topic for ${subject}@${tenant}`);
@@ -170,8 +191,10 @@ class Messenger {
       this.topics.push(topic);
       logger.debug(`config is: ${util.inspect(config, {depth: null})}`);
       if (mode.indexOf('r') != -1) {
-        let consumer = new Consumer(config.consumer);
-        connectConsumer(consumer, topic, subject, tenant);
+        // let consumer = new Consumer(config.consumer);
+        // connectConsumer(consumer, topic, subject, tenant);
+        this.consumer.subscribe(topic);
+        this.consumer.onMessageListener(processKafkaMessagesCbk);
       }
 
       if (mode.indexOf('w') != -1) {
@@ -184,6 +207,7 @@ class Messenger {
     }).catch((error) => {
       logger.warn(`Could not get topic: ${error}`);
     });
+    logger.debug(`... topic for ${subject}@${tenant} was requested.`);
   }
 
   /**

--- a/lib/messenger.js
+++ b/lib/messenger.js
@@ -166,20 +166,6 @@ class Messenger {
       this._processKafkaMessages(subject, tenant, messages);
     };
 
-    let connectConsumer = (consumer, topic, subject, tenant) => {
-      consumer.connect().then(() => {
-        consumer.subscribe(topic, processKafkaMessagesCbk);
-      }).catch((error) => {
-        logger.warn(`Could not connect consumer: ${error}`);
-        logger.warn(`Related info is: ${subject}:${tenant}`);
-        logger.warn("Trying it again in a few seconds.");
-        setTimeout(() => {
-          connectConsumer(consumer, topic);
-        }, 5000);
-      });
-    };
-
-
     logger.debug(`Requesting topic for ${subject}@${tenant}...`);
     this.topicManager.getTopic(subject, tenant, this.config.databroker.host, isGlobal).then((topic) => {
       if (this.topics.indexOf(topic) != -1) {

--- a/lib/sample.js
+++ b/lib/sample.js
@@ -8,6 +8,7 @@ var config = require("./config");
 
 messenger.createChannel("device-data", "rw");
 messenger.createChannel("dojot.tenancy", "r", true);
+messenger.createChannel("iotagent-info", "rw", true);
 
 messenger.on(config.dojot.subjects.deviceData, "message", (tenant, msg) => {
   logger.info(`Client: Received message in device data subject.`);
@@ -15,33 +16,42 @@ messenger.on(config.dojot.subjects.deviceData, "message", (tenant, msg) => {
   logger.info(`Client: Message is: ${msg}`);
 });
 
+
+messenger.on("iotagent-info", "message", (tenant, msg) => {
+  logger.info(`Client: Received message in iotagent-info subject.`);
+  logger.info(`Client: Tenant is: ${tenant}`);
+  logger.info(`Client: Message is: ${msg}`);
+});
+
+
 messenger.on(config.dojot.subjects.devices, "message", (tenant, msg) => {
   logger.info(`Client: Received message in messenger.device-manager.device subject.`);
   logger.info(`Client: Tenant is: ${tenant}`);
   logger.info(`Client: Message is: ${msg}`);
 });
 
-messenger.on(config.dojot.subjects.statistics, "message", (tenant, msg) => {
-  logger.info(`Client: Received message in messenger.device-manager.statistics subject.`);
-  logger.info(`Client: Tenant is: ${tenant}`);
-  logger.info(`Client: Message is: ${msg}`);
-});
+// messenger.on(config.dojot.subjects.statistics, "message", (tenant, msg) => {
+//   logger.info(`Client: Received message in messenger.device-manager.statistics subject.`);
+//   logger.info(`Client: Tenant is: ${tenant}`);
+//   logger.info(`Client: Message is: ${msg}`);
+// });
 
-messenger.on(config.dojot.subjects.tenancy, "new-tenant", (tenant, newtenant) => {
-  logger.info(`Client: Received message in tenancy subject.`);
-  logger.info(`Client: Tenant is: ${newtenant}`);
-});
+// messenger.on(config.dojot.subjects.tenancy, "new-tenant", (tenant, newtenant) => {
+//   logger.info(`Client: Received message in tenancy subject.`);
+//   logger.info(`Client: Tenant is: ${newtenant}`);
+// });
 
-let i = 0;
-let sendMessage = () => {
-  i++;
-  let msg = "this is a device attribute message - " + i;
-  messenger.publish(config.dojot.subjects.deviceData, "admin", msg);
-  setTimeout(() => {
-    sendMessage();
-  }, 10000);
-};
+// let i = 0;
+// let sendMessage = () => {
+//   i++;
+//   let msg = "iotagent - info is this lalaaal" + i;
+//   console.log('oii');
+//   messenger.publish("iotagent-info", "dojot-management", msg);
+//   setTimeout(() => {
+//     sendMessage();
+//   }, 10000);
+// };
 
-sendMessage();
+// sendMessage();
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojot/dojot-module",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "description": "A library that provides utilities and methods for dojot",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR changes the number of consumers used by this library to only one. 

As it seems, a big number of consumers would block other asynchronous operations (such as resolving network names) from being executed. Using only one consumer for all topics will reduce the number of requests to Kafka and, therefore, will let other async callbacks (which might involve IO operations - this is yet to be confirmed) to be executed.