### PR TITLE
Added a fix to retry to get the tenants until it succeeds

### DIFF
--- a/lib/messenger.js
+++ b/lib/messenger.js
@@ -42,8 +42,6 @@ class Messenger {
     let consumer = this.config.kafka.consumer;
     consumer["group.id"] = this.instanceId;
     this.createChannel(this.config.dojot.subjects.tenancy, "r", true, {consumer});
-
-
     this.consumer = new Consumer(this.config.kafka.consumer);
     let connectConsumberFn = () => {
       this.consumer.connect().then(() => {
@@ -63,18 +61,24 @@ class Messenger {
 
     // There should be a auth call here, to get all previous configured
     // tenants.
-    auth.getTenants(this.config.auth.host).then((tenants) => {
-      logger.info(`Retrieved list of tenants: ${tenants}.`);
-      for (const tenant of tenants){ 
-        logger.info(`Bootstrapping tenant ${tenant}...`);
-        this._processNewTenant(this.config.dojot.managementService, JSON.stringify({tenant}));
-        logger.info(`... ${tenant} bootstrapped.`);
-      }
-      logger.info(`Finished tenant bootstrapping.`);
-    }).catch((error) => {
-      logger.error("Could not get list of current tenants.");
-      logger.error(`Error is: ${error}`);
-    });
+    let getAllTenants = (authHost) => {
+      auth.getTenants(authHost).then((tenants) => {
+        logger.info(`Retrieved list of tenants: ${tenants}.`);
+        for (const tenant of tenants){ 
+          logger.info(`Bootstrapping tenant ${tenant}...`);
+          this._processNewTenant(this.config.dojot.managementService, JSON.stringify({tenant}));
+          logger.info(`... ${tenant} bootstrapped.`);
+        }
+        logger.info(`Finished tenant bootstrapping.`);
+      }).catch((error) => {
+        logger.warn(`Could not get list of current tenants: ${error}`);
+        logger.warn("Trying it again in a few seconds.");
+        setTimeout(() => {
+          getAllTenants(authHost);
+        }, 5000);
+      });
+    };
+    getAllTenants(this.config.auth.host);
   }
 
   /**
@@ -223,17 +227,20 @@ class Messenger {
   }
 
   publish(subject, tenant, message) {
-    if (this.producer.isReady == false) {
+    if (this.producer.isReady === false) {
       logger.debug("Producer is not yet ready. Queueing this message.");
       this.queuedMessages.push({subject, tenant, message});
+      return;
     }
     logger.debug(`Trying to publish someting. Current producer topics are ${util.inspect(this.producerTopics, {depth: null})}`);
     if (!(subject in this.producerTopics)) {
       logger.warn(`No producer was created for subject ${subject}. Maybe it was not registered?`);
+      logger.warn(`Message ${message} is being discarded!`);
       return;
     }
     if (!(tenant in this.producerTopics[subject])) {
       logger.warn(`No producer was created for subject ${subject}@${tenant}. Maybe this tenant doesn't exist?`);
+      logger.warn(`Message ${message} is being discarded!`);
       return;
     }
 


### PR DESCRIPTION
If the auth service is not operational, the call to get the tenants fails and it doesn't retry anymore. This PR fixes this problem.
This is connected to dojot/dojot#662