### PR TITLE
fix: fixed a problem with too many tenants

### DIFF
--- a/lib/kafka/Consumer.js
+++ b/lib/kafka/Consumer.js
@@ -12,7 +12,6 @@ class Consumer {
     this.subscriptions = [];
 
     this.consumer.on('data', (kafkaMessage) => {
-      // if (kafkaMessage.topic == topic) {
       logger.debug(`Got a message in topic ${kafkaMessage.topic}.`);
       if (kafkaMessage.topic in this.messageCallbacks) {
         logger.debug(`There are ${this.messageCallbacks[kafkaMessage.topic].length} callbacks registered.`);
@@ -36,7 +35,7 @@ class Consumer {
         logger.info("Consumer is connected");
         clearTimeout(timeoutTrigger);
         this.isReady = true;
-        if (this.subscriptions.length != 0) {
+        if (this.subscriptions.length !== 0) {
           this.consumer.subscribe(this.subscriptions);
         }
         this.consumer.consume();
@@ -55,7 +54,7 @@ class Consumer {
 
     this.messageCallbacks[topic].push(callback);
 
-    if (this.isReady == false) {
+    if (this.isReady === false) {
       this.subscriptions.push(topic);
     } else {
       logger.debug(`Unsubscribing from topics ${this.subscriptions}`);

--- a/lib/kafka/Consumer.js
+++ b/lib/kafka/Consumer.js
@@ -10,6 +10,17 @@ class Consumer {
 
     this.messageCallbacks = {};
     this.subscriptions = [];
+
+    this.consumer.on('data', (kafkaMessage) => {
+      // if (kafkaMessage.topic == topic) {
+      logger.debug(`Got a message in topic ${kafkaMessage.topic}.`);
+      if (kafkaMessage.topic in this.messageCallbacks) {
+        logger.debug(`There are ${this.messageCallbacks[kafkaMessage.topic].length} callbacks registered.`);
+        for (let callback of this.messageCallbacks[kafkaMessage.topic]) {
+          callback(kafkaMessage);
+        }
+      }
+    });
   }
 
   connect() {
@@ -45,7 +56,7 @@ class Consumer {
     this.messageCallbacks[topic].push(callback);
 
     if (this.isReady == false) {
-      this.subscriptions.push(topic);  
+      this.subscriptions.push(topic);
     } else {
       logger.debug(`Unsubscribing from topics ${this.subscriptions}`);
       this.consumer.unsubscribe();
@@ -53,14 +64,7 @@ class Consumer {
       this.subscriptions.push(topic);
       logger.debug(`Subscribing to topics ${this.subscriptions}`);
       this.consumer.subscribe(this.subscriptions);
-      this.consumer.on('data', (kafkaMessage) => {
-        if (kafkaMessage.topic == topic) {
-          for (let callback of this.messageCallbacks[topic]) {
-            callback(kafkaMessage);
-          }
-        }
-      });
-      console.log(`Subscribed to topic ${topic}`);
+      logger.debug(`Subscribed to topic ${topic}.`);
     }
   }
 
@@ -76,7 +80,7 @@ class Consumer {
       });
     });
   }
-  
+
   commit() {
     this.consumer.commit(null);
   }


### PR DESCRIPTION
This PR fixes a important bug which would prevent data from being consumed from Kafka if too many tenants were created.