### PR TITLE
Improving initialization, adding retries to auth and data broker requests

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -34,7 +34,7 @@ function getTenants(auth) {
           authorization: `Bearer ${getManagementToken(config.dojot.management.tenant)}`,
         }
       }).then((response) => {
-        logger.error(`Tenants retrieved: ${response.data.tenants}.`, TAG);
+        logger.info(`Tenants retrieved: ${response.data.tenants}.`, TAG);
         resolve(response.data.tenants);
       }).catch((error) => {
         logger.error(`Could not initialize tenancy consumer: ${error}.`, TAG);

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,6 +1,6 @@
 "use strict";
 var axios = require("axios");
-var config = require("./config");
+var defaultConfig = require("./config");
 var logger = require("@dojot/dojot-module-logger").logger;
 
 const TAG = { filename: "auth" };
@@ -9,7 +9,7 @@ const TAG = { filename: "auth" };
  * Generates a dummy token
  * @param {string} tenant Tenant to be used when creating the token
  */
-function getManagementToken(tenant) {
+function getManagementToken(tenant, config = defaultConfig) {
   const payload = {
     service: tenant,
     username: config.dojot.management.user
@@ -23,7 +23,7 @@ function getManagementToken(tenant) {
   );
 }
 
-function getTenants(auth) {
+function getTenants(auth, config = defaultConfig) {
   const url = `${auth}/admin/tenants`;
   return new Promise((resolve, reject) => {
     let doIt = (counter) => {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -3,6 +3,8 @@ var axios = require("axios");
 var config = require("./config");
 var logger = require("@dojot/dojot-module-logger").logger;
 
+const TAG = { filename: "auth" };
+
 /**
  * Generates a dummy token
  * @param {string} tenant Tenant to be used when creating the token
@@ -21,18 +23,35 @@ function getManagementToken(tenant) {
   );
 }
 
-async function getTenants(auth) {
+function getTenants(auth) {
   const url = `${auth}/admin/tenants`;
-  logger.info(`Retriving tenants from ${url} `);
-
-  let response = await axios({
-    url,
-    method: "get",
-    headers: {
-      authorization: `Bearer ${getManagementToken(config.dojot.management.tenant)}`,
-    }
+  return new Promise((resolve, reject) => {
+    let doIt = (counter) => {
+      axios({
+        url,
+        method: "get",
+        headers: {
+          authorization: `Bearer ${getManagementToken(config.dojot.management.tenant)}`,
+        }
+      }).then((response) => {
+        logger.error(`Tenants retrieved: ${response.data.tenants}.`, TAG);
+        resolve(response.data.tenants);
+      }).catch((error) => {
+        logger.error(`Could not initialize tenancy consumer: ${error}.`, TAG);
+        logger.debug(`Trying again in a few moments.`, TAG);
+        counter--;
+        logger.debug(`Remaining ${counter} time(s).`, TAG);
+        if (counter > 0) {
+          setTimeout(() => {
+            doIt(counter);
+          }, config.auth.timeoutSleep * 1000);
+        } else {
+          reject(`Could not reach Auth.`, TAG);
+        }
+      });
+    };
+    doIt(config.auth.connectionRetries);
   });
-  return response.data.tenants;
 }
 
 module.exports = { getManagementToken, getTenants };

--- a/lib/config.js
+++ b/lib/config.js
@@ -60,7 +60,9 @@ module.exports={
           "metadata.broker.list": process.env.KAFKA_HOSTS || "kafka:9092",
       },
       dojot: {
-          subscriptionHoldoff: Number(process.env.DOJOT_SUBSCRIPTION_HOLDOFF) || 2500
+          subscriptionHoldoff: Number(process.env.DOJOT_SUBSCRIPTION_HOLDOFF) || 2500,
+          timeoutSleep: 5,
+          connectionRetries: 5
       }
     },
     databroker: {

--- a/lib/kafka/Producer.js
+++ b/lib/kafka/Producer.js
@@ -1,9 +1,12 @@
 const Kafka = require('node-rdkafka');
+var logger = require("@dojot/dojot-module-logger").logger;
+
+const TAG = { filename: "producer" };
 
 class Producer {
 
   constructor(config) {
-    console.log('Creating a new Kafka producer...');
+    logger.debug('Creating a new Kafka producer...', TAG);
     this.isReady = false;
     this.producer = new Kafka.Producer(config.kafka.producer);
     this.sendCallback();
@@ -20,7 +23,7 @@ class Producer {
       }, 5000);
 
       this.producer.on("ready", () => {
-        console.log("Producer is ready.");
+        logger.debug("Producer is ready.", TAG);
         this.isReady = true;
         clearTimeout(timeoutTrigger);
         alreadyConnected = true;
@@ -29,7 +32,7 @@ class Producer {
       });
 
       this.producer.on("event.error", (error) => {
-        console.log(`Error while creating producer: ${error}`);
+        logger.debug(`Error while creating producer: ${error}`, TAG);
         if (alreadyConnected == false) {
           reject(error);
         }
@@ -64,7 +67,7 @@ class Producer {
         if (err) {
           reject(err);
         } else {
-          console.log("All messages is flushed.");
+          logger.debug("All messages were flushed.", TAG);
           resolve();
         }
       });
@@ -80,7 +83,7 @@ class Producer {
       throw error;
     }
 
-    console.log("Flush done, disconnecting the producer...");
+    logger.debug("Flush done, disconnecting the producer...", TAG);
 
     const disconnectPromise = new Promise((resolve, reject) => {
       const timeoutTrigger = setTimeout(() => {
@@ -94,7 +97,7 @@ class Producer {
         if (err) {
           console.error(err);
         } else {
-          console.log('disconnected');
+          logger.debug('disconnected', TAG);
           resolve();
         }
       });

--- a/lib/kafka/TopicManager.js
+++ b/lib/kafka/TopicManager.js
@@ -10,9 +10,10 @@ const TAG = { filename: "topic-mgr" };
  * Class for topic management
  */
 class TopicManager {
-  constructor() {
+  constructor(config) {
     this.topics = {};
     this.tenants = [];
+    this.config = config;
   }
 
   getKey(subject, tenant) {
@@ -35,7 +36,7 @@ class TopicManager {
           url,
           method: "get",
           headers: {
-            authorization: `Bearer ${auth.getManagementToken(tenant)}`
+            authorization: `Bearer ${auth.getManagementToken(tenant, this.config)}`
           }
         }).then((response) => {
           this.topics[key] = response.data.topic;
@@ -49,13 +50,13 @@ class TopicManager {
           if (counter > 0) {
             setTimeout(() => {
               doIt(counter);
-            }, config.databroker.timeoutSleep * 1000);
+            }, this.config.databroker.timeoutSleep * 1000);
           } else {
             reject(`Could not reach DataBroker.`);
           }
         });
       };
-      doIt(config.databroker.connectionRetries);
+      doIt(this.config.databroker.connectionRetries);
     });
   }
 }

--- a/lib/kafka/TopicManager.js
+++ b/lib/kafka/TopicManager.js
@@ -2,6 +2,10 @@
 
 var axios = require("axios");
 var auth = require("../auth");
+var config = require("../config");
+var logger = require("@dojot/dojot-module-logger").logger;
+
+const TAG = { filename: "topic-mgr" };
 /**
  * Class for topic management
  */
@@ -25,15 +29,34 @@ class TopicManager {
     const querystring = global ? "?global=true" : "";
     const url = `${broker}/topic/${subject + querystring}`;
 
-    let response = await axios({
-      url,
-      method: "get",
-      headers: {
-        authorization: `Bearer ${auth.getManagementToken(tenant)}`
-      }
+    return new Promise((resolve, reject) => {
+      let doIt = (counter) => {
+        axios({
+          url,
+          method: "get",
+          headers: {
+            authorization: `Bearer ${auth.getManagementToken(tenant)}`
+          }
+        }).then((response) => {
+          this.topics[key] = response.data.topic;
+          resolve(response.data.topic);
+        }).catch((error) => {
+          logger.error(`Could not get topic for ${subject}@${tenant} (global ${global})`, TAG);
+          logger.error(`Error is: ${error}`);
+          logger.debug(`Trying again in a few moments.`, TAG);
+          counter--;
+          logger.debug(`Remaining ${counter} time(s).`, TAG);
+          if (counter > 0) {
+            setTimeout(() => {
+              doIt(counter);
+            }, config.databroker.timeoutSleep * 1000);
+          } else {
+            reject(`Could not reach DataBroker.`);
+          }
+        });
+      };
+      doIt(config.databroker.connectionRetries);
     });
-    this.topics[key] = response.data.topic;
-    return response.data.topic;
   }
 }
 

--- a/lib/kafka/TopicManager.js
+++ b/lib/kafka/TopicManager.js
@@ -2,7 +2,7 @@
 
 var axios = require("axios");
 var auth = require("../auth");
-var config = require("../config");
+var defaultConfig = require("../config");
 var logger = require("@dojot/dojot-module-logger").logger;
 
 const TAG = { filename: "topic-mgr" };
@@ -10,7 +10,7 @@ const TAG = { filename: "topic-mgr" };
  * Class for topic management
  */
 class TopicManager {
-  constructor(config) {
+  constructor(config = defaultConfig) {
     this.topics = {};
     this.tenants = [];
     this.config = config;

--- a/lib/messenger.js
+++ b/lib/messenger.js
@@ -10,6 +10,8 @@ var logger = require("@dojot/dojot-module-logger").logger;
 var auth = require("./auth");
 var axios = require("axios");
 
+const TAG = { filename: "messenger" };
+
 /**
  * Class responsible for sending and receiving messages through Kafka using
  * dojot subjects and tenants.
@@ -32,9 +34,9 @@ var axios = require("axios");
  *
  * // Register callback to process incoming device data
  * messenger.on(config.dojot.subjects.deviceData, "message", (tenant, msg) => {
- *   logger.info(`Client: Received message in device data subject.`);
- *   logger.info(`Client: Tenant is: ${tenant}`);
- *   logger.info(`Client: Message is: ${msg}`);
+ *   logger.info(`Client: Received message in device data subject.`, TAG);
+ *   logger.info(`Client: Tenant is: ${tenant}`, TAG);
+ *   logger.info(`Client: Message is: ${msg}`, TAG);
  * });
  *
  * // Publish a message on "service-status" subject using "dojot-management" tenant
@@ -83,7 +85,7 @@ class Messenger {
     const { kafka } = JSON.parse(JSON.stringify(this.config));
 
     kafka.producer["client.id"] = this.instanceId;
-    logger.info(`Building new producer: ${util.inspect({kafka})}`);
+    logger.info(`Building new producer: ${util.inspect({kafka})}`, TAG);
     this.producer = new Producer({ kafka });
 
     // Removing "group.id" attribute and leaving the others.
@@ -110,21 +112,21 @@ class Messenger {
       const subject = this.config.dojot.subjects.tenancy;
       const tenant = this.config.dojot.management.tenant;
 
-      logger.debug(`Initializing tenancy consumer...`);
+      logger.debug(`Initializing tenancy consumer...`, TAG);
       this.globalSubjects[subject] = { mode: "r" };
-      logger.debug(`Requesting topic for ${subject}@${tenant} to ${this.config.databroker.url}...`);
+      logger.debug(`Requesting topic for ${subject}@${tenant} to ${this.config.databroker.url}...`, TAG);
       this.topicManager.getTopic(subject, tenant, this.config.databroker.url, true).then((topic) => {
 
-        logger.debug(`Got topic for subject ${subject} and tenant ${tenant}: ${topic}`);
+        logger.debug(`Got topic for subject ${subject} and tenant ${tenant}: ${topic}`, TAG);
         this.topics.push(topic);
         this._tenancyConsumer.subscribe(topic, (messages) => {
           this._processKafkaMessages(subject, tenant, messages);
         });
-        logger.debug(`... topic for ${subject}@${tenant} was requested.`);
+        logger.debug(`... topic for ${subject}@${tenant} was requested.`, TAG);
 
-        logger.debug("Registering callback for tenancy consumer...");
+        logger.debug("Registering callback for tenancy consumer...", TAG);
         this.on(subject, "message", this._processNewTenant.bind(this));
-        logger.debug("... callback registered for tenancy consumer.");
+        logger.debug("... callback registered for tenancy consumer.", TAG);
         resolve();
       }).catch((error) => {
           reject(`Could not reach Data Broker: ${error}.`);
@@ -139,14 +141,14 @@ class Messenger {
   async init() {
     let connectConsumerFn = (resolve, reject, client, counter) => {
       client.connect().then(() => {
-        logger.info(`Kafka client connected`);
+        logger.info(`Kafka client connected`, TAG);
         resolve();
         return;
       }).catch((error) => {
-        logger.warn(`Could not connect Kafka client: ${error}`);
-        logger.warn(`Trying it again in ${this.config.kafka.dojot.timeoutSleep} seconds.`);
+        logger.warn(`Could not connect Kafka client: ${error}`, TAG);
+        logger.warn(`Trying it again in ${this.config.kafka.dojot.timeoutSleep} seconds.`, TAG);
         counter--;
-        logger.debug(`Remaining ${counter} times`);
+        logger.debug(`Remaining ${counter} times`, TAG);
         if (counter > 0) {
           setTimeout(() => {
             connectConsumerFn(resolve, reject, client, counter);
@@ -159,15 +161,15 @@ class Messenger {
 
     // Wait for all consumers to connect to Kafka brokers.
     const counter = this.config.kafka.dojot.connectionRetries;
-    logger.debug("Connecting Kafka producer...");
+    logger.debug("Connecting Kafka producer...", TAG);
     await new Promise((resolve, reject) => { connectConsumerFn(resolve, reject, this.producer, counter);});
-    logger.debug("... Kafka producer successfully connected.");
-    logger.debug("Connecting Kafka consumer for tenancy data...");
+    logger.debug("... Kafka producer successfully connected.", TAG);
+    logger.debug("Connecting Kafka consumer for tenancy data...", TAG);
     await new Promise((resolve, reject) => { connectConsumerFn(resolve, reject, this._tenancyConsumer, counter); });
-    logger.debug("... Kafka consumer for tenancy data successfully connected.");
-    logger.debug("Connecting Kafka consumer for common messages...");
+    logger.debug("... Kafka consumer for tenancy data successfully connected.", TAG);
+    logger.debug("Connecting Kafka consumer for common messages...", TAG);
     await new Promise((resolve, reject) => { connectConsumerFn(resolve, reject, this.consumer, counter); });
-    logger.debug("... Kafka consumer for common messages successfully connected.");
+    logger.debug("... Kafka consumer for common messages successfully connected.", TAG);
     await this._initTenancyConsumer();
     await auth.getTenants(this.config.auth.url);
   }
@@ -180,26 +182,26 @@ class Messenger {
    * @param {string} msg The message describing the new tenant.
    */
   _processNewTenant(tenant, msg) {
-    logger.debug(`Received message in tenancy subject.`);
-    logger.debug(`Tenant is: ${tenant}`);
-    logger.debug(`Message is: ${util.inspect(msg, {depth: null})}`);
+    logger.debug(`Received message in tenancy subject.`, TAG);
+    logger.debug(`Tenant is: ${tenant}`, TAG);
+    logger.debug(`Message is: ${util.inspect(msg, {depth: null})}`, TAG);
 
     let data;
     try {
       data = JSON.parse(msg);
     } catch (error) {
-      logger.warn("Data is not a valid JSON. Bailing out.");
-      logger.warn(`Error is: ${error}`);
+      logger.warn("Data is not a valid JSON. Bailing out.", TAG);
+      logger.warn(`Error is: ${error}`, TAG);
       return;
     }
 
     // Perform some sanity checks here
     if (!("tenant" in data)) {
-      logger.warn("Received message is invalid. Bailing out.");
+      logger.warn("Received message is invalid. Bailing out.", TAG);
       return;
     }
     if (this.tenants.indexOf(data.tenant) != -1) {
-      logger.warn("This tenant was already registered. Bailing out.");
+      logger.warn("This tenant was already registered. Bailing out.", TAG);
       return;
     }
 
@@ -218,15 +220,15 @@ class Messenger {
    * @param {Object} data The message (or object)
    */
   emit(subject, tenant, event, data) {
-    logger.debug(`Emitting new event ${event} for subject ${subject}@${tenant}`);
+    logger.debug(`Emitting new event ${event} for subject ${subject}@${tenant}`, TAG);
     // Sanity checks
     if (!(subject in this.eventCallbacks)) {
-      logger.debug(`No one is listening to subject ${subject} events.`);
+      logger.debug(`No one is listening to subject ${subject} events.`, TAG);
       return;
     }
 
     if (!(event in this.eventCallbacks[subject])) {
-      logger.debug(`No one is listening to subject ${subject} ${event} events.`);
+      logger.debug(`No one is listening to subject ${subject} ${event} events.`, TAG);
       return;
     }
     // Maybe we should use async.parallel or async.waterfall here?
@@ -245,7 +247,7 @@ class Messenger {
    * @param {function} callback
    */
   on(subject, event, callback) {
-    logger.debug(`Registering new callback for subject ${subject} and event ${event}`);
+    logger.debug(`Registering new callback for subject ${subject} and event ${event}`, TAG);
     if (!(subject in this.eventCallbacks)) {
       this.eventCallbacks[subject] = {};
     }
@@ -275,29 +277,29 @@ class Messenger {
       this._processKafkaMessages(subject, tenant, messages);
     };
 
-    logger.debug(`Requesting topic for ${subject}@${tenant}...`);
+    logger.debug(`Requesting topic for ${subject}@${tenant}...`, TAG);
     this.topicManager.getTopic(subject, tenant, this.config.databroker.url, isGlobal).then((topic) => {
       if (this.topics.indexOf(topic) != -1) {
-        logger.info(`already have a topic for ${subject}@${tenant}`);
+        logger.info(`already have a topic for ${subject}@${tenant}`, TAG);
         return;
       }
-      logger.debug(`Got topic for subject ${subject} and tenant ${tenant}: ${topic}`);
+      logger.debug(`Got topic for subject ${subject} and tenant ${tenant}: ${topic}`, TAG);
       this.topics.push(topic);
       if (mode.indexOf('r') != -1) {
         this.consumer.subscribe(topic, processKafkaMessagesCbk);
       }
 
       if (mode.indexOf('w') != -1) {
-        logger.debug("Adding a producer topic.");
+        logger.debug("Adding a producer topic.", TAG);
         if (!(subject in this.producerTopics)) {
           this.producerTopics[subject] = {};
         }
         this.producerTopics[subject][tenant] = topic;
       }
     }).catch((error) => {
-      logger.warn(`Could not get topic: ${error}`);
+      logger.warn(`Could not get topic: ${error}`, TAG);
     });
-    logger.debug(`... topic for ${subject}@${tenant} was requested.`);
+    logger.debug(`... topic for ${subject}@${tenant} was requested.`, TAG);
   }
 
   /**
@@ -309,7 +311,7 @@ class Messenger {
    * (is it group by tenants, such as in "device-data" subject, or not, such as in "dojot.tenancy"?)
    */
   createChannel(subject, mode = "r", isGlobal = false) {
-    logger.info(`Creating channel for subject ${subject}`);
+    logger.info(`Creating channel for subject ${subject}`, TAG);
     let associatedTenants = [];
     if (isGlobal === true) {
       associatedTenants = [this.config.dojot.management.tenant];
@@ -325,25 +327,25 @@ class Messenger {
   }
 
   _processKafkaMessages(subject, tenant, messages) {
-      logger.debug(`Received message: ${util.inspect(messages, {depth: null})} `);
+      logger.debug(`Received message: ${util.inspect(messages, {depth: null})} `, TAG);
       this.emit(subject, tenant, "message", messages.value.toString("utf-8"));
   }
 
   publish(subject, tenant, message) {
     if (this.producer.isReady === false) {
-      logger.debug("Producer is not yet ready. Queueing this message.");
+      logger.debug("Producer is not yet ready. Queueing this message.", TAG);
       this.queuedMessages.push({subject, tenant, message});
       return;
     }
-    logger.debug(`Trying to publish someting. Current producer topics are ${util.inspect(this.producerTopics, {depth: null})}`);
+    logger.debug(`Trying to publish someting. Current producer topics are ${util.inspect(this.producerTopics, {depth: null})}`, TAG);
     if (!(subject in this.producerTopics)) {
-      logger.warn(`No producer was created for subject ${subject}. Maybe it was not registered?`);
-      logger.warn(`Message ${message} is being discarded!`);
+      logger.warn(`No producer was created for subject ${subject}. Maybe it was not registered?`, TAG);
+      logger.warn(`Message ${message} is being discarded!`, TAG);
       return;
     }
     if (!(tenant in this.producerTopics[subject])) {
-      logger.warn(`No producer was created for subject ${subject}@${tenant}. Maybe this tenant doesn't exist?`);
-      logger.warn(`Message ${message} is being discarded!`);
+      logger.warn(`No producer was created for subject ${subject}@${tenant}. Maybe this tenant doesn't exist?`, TAG);
+      logger.warn(`Message ${message} is being discarded!`, TAG);
       return;
     }
 
@@ -351,7 +353,7 @@ class Messenger {
   }
 
   generateDeviceCreateEventForActiveDevices() {
-    logger.debug('Requesting all active devices');
+    logger.debug('Requesting all active devices', TAG);
     let requestDevice = (tenant, pageNum) => {
       let extraArg = '';
       if (pageNum > 0) {
@@ -381,7 +383,7 @@ class Messenger {
           requestDevice(tenant, response.data.pagination.next_page);
         }
       }).catch ( (error) => {
-        logger.error(error);
+        logger.error(error, TAG);
       });
     }
 

--- a/lib/messenger.js
+++ b/lib/messenger.js
@@ -85,17 +85,6 @@ class Messenger {
     kafka.producer["client.id"] = this.instanceId;
     logger.info(`Building new producer: ${util.inspect({kafka})}`);
     this.producer = new Producer({ kafka });
-    this.producer.connect().then(() => {
-      logger.info(`Producer for module ${this.instanceId} is ready.`);
-      logger.info(`Sending pending messages...`);
-      for (let msg of this.queuedMessages) {
-        this.publish(msg.subject, msg.tenant, msg.message);
-      }
-      this.queuedMessages = [];
-    }).catch((error) => {
-      logger.error(`Could not create producer: ${error}`);
-      process.exit(-1);
-    });
 
     // Removing "group.id" attribute and leaving the others.
     const { "group.id": userGroup, ...tenancyConfig} = kafka.consumer;
@@ -206,7 +195,23 @@ class Messenger {
       });
     };
 
+    let connectProducerFn = (resolve, reject, producer) => {
+      producer.connect().then(() => {
+        logger.info(`Producer for module ${this.instanceId} is ready.`);
+        logger.info(`Sending pending messages...`);
+        for (let msg of this.queuedMessages) {
+          this.publish(msg.subject, msg.tenant, msg.message);
+        }
+        this.queuedMessages = [];
+        resolve();
+      }).catch((error) => {
+        logger.error(`Could not create producer: ${error}`);
+        reject(error);
+      });
+    }
+
     // Wait for all consumers to connect to Kafka brokers.
+    await new Promise((resolve, reject) => { connectProducerFn(resolve, reject, this.producer);});
     await new Promise((resolve) => { connectConsumerFn(resolve, this._tenancyConsumer); });
     await new Promise((resolve) => { connectConsumerFn(resolve, this.consumer); });
     await new Promise((resolve, reject) => { this._initTenancyConsumer(resolve, reject); });

--- a/lib/messenger.js
+++ b/lib/messenger.js
@@ -66,7 +66,7 @@ var axios = require("axios");
  */
 class Messenger {
   constructor(name, config) {
-    this.topicManager = new TopicManager();
+    this.topicManager = new TopicManager(config);
     this.eventCallbacks = {};
     this.tenants = [];
     this.subjects = {};

--- a/lib/messenger.js
+++ b/lib/messenger.js
@@ -105,28 +105,30 @@ class Messenger {
    * This function will properly initialize it (it is quite the same operations
    * as for "normal" subjects).
    */
-  _initTenancyConsumer(resolve, reject) {
-    const subject = this.config.dojot.subjects.tenancy;
-    const tenant = this.config.dojot.management.tenant;
+  async _initTenancyConsumer() {
+    return new Promise((resolve, reject) => {
+      const subject = this.config.dojot.subjects.tenancy;
+      const tenant = this.config.dojot.management.tenant;
 
-    logger.debug(`Initializing tenancy consumer...`);
-    this.globalSubjects[subject] = { mode: "r" };
-    logger.debug(`Requesting topic for ${subject}@${tenant} to ${this.config.databroker.url}...`);
-    this.topicManager.getTopic(subject, tenant, this.config.databroker.url, true).then((topic) => {
+      logger.debug(`Initializing tenancy consumer...`);
+      this.globalSubjects[subject] = { mode: "r" };
+      logger.debug(`Requesting topic for ${subject}@${tenant} to ${this.config.databroker.url}...`);
+      this.topicManager.getTopic(subject, tenant, this.config.databroker.url, true).then((topic) => {
 
-      logger.debug(`Got topic for subject ${subject} and tenant ${tenant}: ${topic}`);
-      this.topics.push(topic);
-      this._tenancyConsumer.subscribe(topic, (messages) => {
-        this._processKafkaMessages(subject, tenant, messages);
+        logger.debug(`Got topic for subject ${subject} and tenant ${tenant}: ${topic}`);
+        this.topics.push(topic);
+        this._tenancyConsumer.subscribe(topic, (messages) => {
+          this._processKafkaMessages(subject, tenant, messages);
+        });
+        logger.debug(`... topic for ${subject}@${tenant} was requested.`);
+
+        logger.debug("Registering callback for tenancy consumer...");
+        this.on(subject, "message", this._processNewTenant.bind(this));
+        logger.debug("... callback registered for tenancy consumer.");
+        resolve();
+      }).catch((error) => {
+          reject(`Could not reach Data Broker: ${error}.`);
       });
-      logger.debug(`... topic for ${subject}@${tenant} was requested.`);
-
-      logger.debug("Registering callback for tenancy consumer...");
-      this.on(subject, "message", this._processNewTenant.bind(this));
-      logger.debug("... callback registered for tenancy consumer.");
-      resolve();
-    }).catch((error) => {
-        reject(`Could not reach Data Broker: ${error}.`);
     });
   }
 
@@ -135,40 +137,38 @@ class Messenger {
    * @return a promise
    */
   async init() {
-    let connectConsumerFn = (resolve, consumer) => {
-      consumer.connect().then(() => {
-        logger.info(`Consumer connected`);
+    let connectConsumerFn = (resolve, reject, client, counter) => {
+      client.connect().then(() => {
+        logger.info(`Kafka client connected`);
         resolve();
         return;
       }).catch((error) => {
-        logger.warn(`Could not connect consumer: ${error}`);
-        logger.warn("Trying it again in 5 seconds.");
-        setTimeout(() => {
-          connectConsumerFn(resolve, consumer);
-        }, 5000);
+        logger.warn(`Could not connect Kafka client: ${error}`);
+        logger.warn(`Trying it again in ${this.config.kafka.dojot.timeoutSleep} seconds.`);
+        counter--;
+        logger.debug(`Remaining ${counter} times`);
+        if (counter > 0) {
+          setTimeout(() => {
+            connectConsumerFn(resolve, reject, client, counter);
+          }, this.config.kafka.dojot.timeoutSleep);
+        } else {
+          reject(`Could not connect Kafka consumer: ${error}`);
+        }
       });
     };
 
-    let connectProducerFn = (resolve, reject, producer) => {
-      producer.connect().then(() => {
-        logger.info(`Producer for module ${this.instanceId} is ready.`);
-        logger.info(`Sending pending messages...`);
-        for (let msg of this.queuedMessages) {
-          this.publish(msg.subject, msg.tenant, msg.message);
-        }
-        this.queuedMessages = [];
-        resolve();
-      }).catch((error) => {
-        logger.error(`Could not create producer: ${error}`);
-        reject(error);
-      });
-    }
-
     // Wait for all consumers to connect to Kafka brokers.
-    await new Promise((resolve, reject) => { connectProducerFn(resolve, reject, this.producer);});
-    await new Promise((resolve) => { connectConsumerFn(resolve, this._tenancyConsumer); });
-    await new Promise((resolve) => { connectConsumerFn(resolve, this.consumer); });
-    await new Promise(this._initTenancyConsumer.bind(this));
+    const counter = this.config.kafka.dojot.connectionRetries;
+    logger.debug("Connecting Kafka producer...");
+    await new Promise((resolve, reject) => { connectConsumerFn(resolve, reject, this.producer, counter);});
+    logger.debug("... Kafka producer successfully connected.");
+    logger.debug("Connecting Kafka consumer for tenancy data...");
+    await new Promise((resolve, reject) => { connectConsumerFn(resolve, reject, this._tenancyConsumer, counter); });
+    logger.debug("... Kafka consumer for tenancy data successfully connected.");
+    logger.debug("Connecting Kafka consumer for common messages...");
+    await new Promise((resolve, reject) => { connectConsumerFn(resolve, reject, this.consumer, counter); });
+    logger.debug("... Kafka consumer for common messages successfully connected.");
+    await this._initTenancyConsumer();
     await auth.getTenants(this.config.auth.url);
   }
 

--- a/lib/messenger.js
+++ b/lib/messenger.js
@@ -105,7 +105,7 @@ class Messenger {
    * This function will properly initialize it (it is quite the same operations
    * as for "normal" subjects).
    */
-  _initTenancyConsumer(resolve, reject, counter = undefined) {
+  _initTenancyConsumer(resolve, reject) {
     const subject = this.config.dojot.subjects.tenancy;
     const tenant = this.config.dojot.management.tenant;
 
@@ -126,55 +126,9 @@ class Messenger {
       logger.debug("... callback registered for tenancy consumer.");
       resolve();
     }).catch((error) => {
-      logger.error(`Could not initialize tenancy consumer: ${error}.`);
-      logger.debug(`Trying again in ${this.config.databroker.timeoutSleep}ms.`);
-      if (counter == undefined) {
-        counter = this.config.databroker.connectionRetries;
-      } else {
-        counter--;
-      }
-
-      logger.debug(`Remaining ${counter} time(s).`);
-      if (counter > 0) {
-        setTimeout(() => {
-          this._initTenancyConsumer(resolve, reject, counter);
-        }, this.config.databroker.timeoutSleep * 1000);
-      } else {
-        reject(`Could not reach DataBroker.`);
-      }
+        reject(`Could not reach Data Broker: ${error}.`);
     });
   }
-
-  // Initialize pre-existing tenants.
-  _getAllTenants(resolve, reject, counter = undefined) {
-    auth.getTenants(this.config.auth.url).then((tenants) => {
-      logger.info(`Retrieved list of tenants: ${tenants}.`);
-      for (const tenant of tenants) {
-        logger.info(`Bootstrapping tenant ${tenant}...`);
-        this._processNewTenant(this.config.dojot.management.tenant, JSON.stringify({ tenant }));
-        logger.info(`... ${tenant} bootstrapped.`);
-      }
-      logger.info(`Finished tenant bootstrapping.`);
-      resolve();
-    }).catch((error) => {
-      logger.error(`Could not initialize tenancy consumer: ${error}.`);
-      logger.debug(`Trying again in a few moments.`);
-      if (counter == undefined) {
-        counter = this.config.auth.connectionRetries;
-      } else {
-        counter--;
-      }
-
-      logger.debug(`Remaining ${counter} time(s).`);
-      if (counter > 0) {
-        setTimeout(() => {
-          this._getAllTenants(resolve, reject, counter);
-        }, this.config.auth.timeoutSleep * 1000);
-      } else {
-        reject(`Could not reach Auth.`);
-      }
-    });
-  };
 
   /**
    * Initializes the messenger
@@ -214,8 +168,8 @@ class Messenger {
     await new Promise((resolve, reject) => { connectProducerFn(resolve, reject, this.producer);});
     await new Promise((resolve) => { connectConsumerFn(resolve, this._tenancyConsumer); });
     await new Promise((resolve) => { connectConsumerFn(resolve, this.consumer); });
-    await new Promise((resolve, reject) => { this._initTenancyConsumer(resolve, reject); });
-    await new Promise((resolve, reject) => { this._getAllTenants(resolve, reject); });
+    await new Promise(this._initTenancyConsumer.bind(this));
+    await auth.getTenants(this.config.auth.url);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojot/dojot-module",
-  "version": "0.0.1-beta.1",
+  "version": "0.0.1-beta.2",
   "description": "A library that provides utilities and methods for dojot",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR adds three changes:

- Now Producer initialization is performed within Messenger's init function. This way a user can identify whether its initial connection succeeded or not.
- Auth requests will be sent a few times (set by conf.auth.connectionRetries) before generating an error (which can be detected by the user)
- The same thing for Data Broker requests.

This is connected to dojot/dojot#781 and is connected to dojot/dojot#888.