### PR TITLE
updating version node-rdkafka lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojot/dojot-module",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7797,12 +7797,12 @@
       }
     },
     "node-rdkafka": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.5.1.tgz",
-      "integrity": "sha512-tC7LeyshdZEds+nx0RicLn9Cam0ahpGIDNY+QAD82K/UpD2rAMIM4K/Z8NUnlnvCaLukA7229agSMogG23XcTA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.9.1.tgz",
+      "integrity": "sha512-C5EVDZlDG+5D8KXiz2zKwEiLWIGW5Z1mkVFRzp13T4mrbXz+ESyjrDSLIj7aoUIi5+T10H9p1wwLZJBh9ivjLg==",
       "requires": {
         "bindings": "^1.3.1",
-        "nan": "^2.11.1"
+        "nan": "^2.14.0"
       }
     },
     "nopt": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@dojot/dojot-module",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A library that provides utilities and methods for dojot",
   "engines": {
-    "node": "<11.0.0"
+    "node": "<14"
   },
   "main": "index.js",
   "scripts": {
@@ -49,7 +49,7 @@
     "axios": "^0.18.0",
     "express": "^4.16.3",
     "moment": "^2.22.2",
-    "node-rdkafka": "2.5.1",
+    "node-rdkafka": "2.9.1",
     "uuid": "^3.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The version of the `node-rdkafka` library has been updated to `2.9.1`. The same as the one used by `dojot-microservice-sdk-js` [v0.1.9 - npm-shrinkwrap.json](https://github.com/dojot/dojot-microservice-sdk-js/blob/v0.1.9/npm-shrinkwrap.json#L5848).

In this way it is possible to use the two libraries together (dojot-module-nodejs and dojot-microservice-sdk-js)

The supported Node.js version is now `v12` and no longer `v10`.